### PR TITLE
翻译文件小改动

### DIFF
--- a/PathCopyCopy/localization/PathCopyCopyLocalization_en/rsrc/PathCopyCopyLocalization_en.rc
+++ b/PathCopyCopy/localization/PathCopyCopyLocalization_en/rsrc/PathCopyCopyLocalization_en.rc
@@ -123,7 +123,7 @@ LANGUAGE LANG_FRENCH, SUBLANG_FRENCH_CANADIAN
 #pragma code_page(1252)
 
 /////////////////////////////////////////////////////////////////////////////
-// Chinese (Simplified, PRC) resources
+// Chinese (Simplified) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_CHS)
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
@@ -158,7 +158,7 @@ END
 /////////////////////////////////////////////////////////////////////////////
 
 
-#endif    // Chinese (Simplified, PRC) resources
+#endif    // Chinese (Simplified) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/PathCopyCopy/localization/PathCopyCopyLocalization_fr/rsrc/PathCopyCopyLocalization_fr.rc
+++ b/PathCopyCopy/localization/PathCopyCopyLocalization_fr/rsrc/PathCopyCopyLocalization_fr.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 BEGIN
     IDS_PROJNAME            "PathCopyCopy"
     IDS_PATH_COPY_MENU_ITEM "Copie du c&hemin"
-    IDS_PATH_COPY_HINT      "Copie le(s) chemin(s) du/des fichiers sélectionnés dans divers formats."
+    IDS_PATH_COPY_HINT      "Copie le(s) chemin(s) du/des fichiers sÃ©lectionnÃ©s dans divers formats."
     IDS_SAMPLE_PLUGIN_DESCRIPTION "Copier le chemin exemple"
     IDS_SAMPLE_PLUGIN_HINT  "Copies the path of the given file using the sample plugin."
     IDS_SHORT_NAME_PLUGIN_DESCRIPTION "Copier le no&m court"
@@ -49,41 +49,41 @@ BEGIN
                             "Copie le chemin long du fichier/dossier dans le presse-papier."
     IDS_LONG_UNC_PATH_PLUGIN_DESCRIPTION "Copier le chemin &UNC long"
     IDS_LONG_UNC_PATH_PLUGIN_HINT 
-                            "Copie le chemin UNC long (partage réseau) du fichier/dossier dans le presse-papier, s'il possède un tel chemin; sinon, copie son chemin long."
+                            "Copie le chemin UNC long (partage rÃ©seau) du fichier/dossier dans le presse-papier, s'il possÃ¨de un tel chemin; sinon, copie son chemin long."
     IDS_INTERNET_PATH_PLUGIN_DESCRIPTION 
                             "Copier le chemin en format &internet"
     IDS_INTERNET_PATH_PLUGIN_HINT 
                             "Copie le chemin du fichier/dossier dans le presse-papier en format lien internet file://."
     IDS_UNIX_PATH_PLUGIN_DESCRIPTION "Copier le chemin Uni&x"
     IDS_UNIX_PATH_PLUGIN_HINT 
-                            "Copie le chemin du fichier/dossier dans le presse-papier, remplaçant les barres obliques inverses en barres obliques."
+                            "Copie le chemin du fichier/dossier dans le presse-papier, remplaÃ§ant les barres obliques inverses en barres obliques."
     IDS_CYGWIN_PATH_PLUGIN_DESCRIPTION "Copier le chemin Cy&gwin"
     IDS_CYGWIN_PATH_PLUGIN_HINT 
                             "Copie le chemin du fichier/dossier dans le presse-papier dans un format reconnu par les outils Cygwin."
     IDS_DEFAULT_PLUGIN_DESCRIPTION "Copier le &chemin du fichier/dossier"
     IDS_SHORT_UNC_PATH_PLUGIN_DESCRIPTION "Copier le chemin UN&C court"
     IDS_SHORT_UNC_PATH_PLUGIN_HINT 
-                            "Copie le chemin UNC court (partage réseau) du fichier/dossier dans le presse-papier, s'il possède un tel chemin; sinon, copie son chemin court."
+                            "Copie le chemin UNC court (partage rÃ©seau) du fichier/dossier dans le presse-papier, s'il possÃ¨de un tel chemin; sinon, copie son chemin court."
 END
 
 STRINGTABLE
 BEGIN
     IDS_LONG_FOLDER_PLUGIN_DESCRIPTION "Copier le chemin long du &parent"
     IDS_LONG_FOLDER_PLUGIN_HINT 
-                            "Copie le chemin long du répertoire parent du fichier/dossier dans le presse-papier."
+                            "Copie le chemin long du rÃ©pertoire parent du fichier/dossier dans le presse-papier."
     IDS_SHORT_FOLDER_PLUGIN_DESCRIPTION "Copier le chemin court du p&arent"
     IDS_SHORT_FOLDER_PLUGIN_HINT 
-                            "Copie le chemin court du répertoire parent du fichier/dossier dans le presse-papier."
+                            "Copie le chemin court du rÃ©pertoire parent du fichier/dossier dans le presse-papier."
     IDS_SHORT_UNC_FOLDER_PLUGIN_DESCRIPTION 
                             "Copier le chemin UNC cou&rt du parent"
     IDS_SHORT_UNC_FOLDER_PLUGIN_HINT 
-                            "Copie le chemin UNC court (partage réseau) du répertoire parent du fichier/dossier dans le presse-papier, s'il possède un tel chemin; sinon, copie son chemin court."
+                            "Copie le chemin UNC court (partage rÃ©seau) du rÃ©pertoire parent du fichier/dossier dans le presse-papier, s'il possÃ¨de un tel chemin; sinon, copie son chemin court."
     IDS_LONG_UNC_FOLDER_PLUGIN_DESCRIPTION 
                             "Copier le chemin UNC long du paren&t"
     IDS_LONG_UNC_FOLDER_PLUGIN_HINT 
-                            "Copie le chemin UNC long (partage réseau) du répertoire parent du fichier/dossier dans le presse-papier, s'il possède un tel chemin; sinon, copie son chemin long."
-    IDS_PCC_SETTINGS_DESCRIPTION "Paramètres..."
-    IDS_PCC_SETTINGS_HINT   "Ouvre la fenêtre permettant de paramétrer cet outil."
+                            "Copie le chemin UNC long (partage rÃ©seau) du rÃ©pertoire parent du fichier/dossier dans le presse-papier, s'il possÃ¨de un tel chemin; sinon, copie son chemin long."
+    IDS_PCC_SETTINGS_DESCRIPTION "ParamÃ¨tres..."
+    IDS_PCC_SETTINGS_HINT   "Ouvre la fenÃªtre permettant de paramÃ©trer cet outil."
     IDS_SETTINGS_APP_FILE_NAME "PathCopyCopySettings.exe"
     IDS_REDUNDANT_WORD_COPY "Copier le "
     IDS_ANDROGYNOUS_NAME_PLUGIN_DESCRIPTION "Copier le &nom"
@@ -105,13 +105,13 @@ BEGIN
     IDS_MSYS_PATH_PLUGIN_DESCRIPTION "Copier le chemin MS&YS/MSYS2"
     IDS_MSYS_PATH_PLUGIN_HINT 
                             "Copie le chemin du fichier/dossier dans le presse-papier en format MSYS/MSYS2."
-    IDS_INVALIDPIPELINE     "<< Commande personnalisée invalide >>"
+    IDS_INVALIDPIPELINE     "<< Commande personnalisÃ©e invalide >>"
     IDS_INVALIDPIPELINE_LOOP_DETECTED 
-                            "<< Boucle détectée dans les éléments de la commande personnalisée >>"
+                            "<< Boucle dÃ©tectÃ©e dans les Ã©lÃ©ments de la commande personnalisÃ©e >>"
     IDS_INVALIDPIPELINE_POSSIBLE_DOWNGRADE 
-                            "<< Élément invalide dans la commande personnalisée (rétrogradation de version possible) >>"
+                            "<< Ã‰lÃ©ment invalide dans la commande personnalisÃ©e (rÃ©trogradation de version possible) >>"
     IDS_INVALIDPIPELINE_BASE_COMMAND_NOT_FOUND 
-                            "<< Commande de base non-trouvée >>"
+                            "<< Commande de base non-trouvÃ©e >>"
 END
 
 #endif    // English (United States) resources
@@ -126,7 +126,7 @@ LANGUAGE LANG_FRENCH, SUBLANG_FRENCH_CANADIAN
 #pragma code_page(1252)
 
 /////////////////////////////////////////////////////////////////////////////
-// Chinese (Simplified, PRC) resources
+// Chinese (Simplified) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_CHS)
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
@@ -161,7 +161,7 @@ END
 /////////////////////////////////////////////////////////////////////////////
 
 
-#endif    // Chinese (Simplified, PRC) resources
+#endif    // Chinese (Simplified) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/PathCopyCopy/localization/PathCopyCopyLocalization_zh/rsrc/PathCopyCopyLocalization_zh.rc
+++ b/PathCopyCopy/localization/PathCopyCopyLocalization_zh/rsrc/PathCopyCopyLocalization_zh.rc
@@ -27,87 +27,87 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 STRINGTABLE
 BEGIN
     IDS_PROJNAME            "PathCopyCopy"
-    IDS_PATH_COPY_MENU_ITEM "&路径复制"
+    IDS_PATH_COPY_MENU_ITEM "复制路径(&P)"
     IDS_PATH_COPY_HINT      "将所选文件的路径以不同格式复制到剪贴板。"
-    IDS_SAMPLE_PLUGIN_DESCRIPTION "Copy Sample Path"
-    IDS_SAMPLE_PLUGIN_HINT  "Copies the path of the given file using the sample plugin."
-    IDS_SHORT_NAME_PLUGIN_DESCRIPTION "复制短&名称"
+    IDS_SAMPLE_PLUGIN_DESCRIPTION "复制「示例」路径"
+    IDS_SAMPLE_PLUGIN_HINT  "使用「示例」插件复制指定文件的路径。"
+    IDS_SHORT_NAME_PLUGIN_DESCRIPTION "复制短名称(&N)"
     IDS_SHORT_NAME_PLUGIN_HINT 
-                            "复制文件/文件夹的短名称到剪贴板（不含路径）。"
-    IDS_LONG_NAME_PLUGIN_DESCRIPTION "复制长&名称"
+                            "将文件/文件夹的短名称复制到剪贴板（不含路径）。"
+    IDS_LONG_NAME_PLUGIN_DESCRIPTION "复制长名称(&A)"
     IDS_LONG_NAME_PLUGIN_HINT 
-                            "复制文件/文件夹的长名称到剪贴板（不含路径）。"
-    IDS_SHORT_PATH_PLUGIN_DESCRIPTION "复制&短路径"
+                            "将文件/文件夹的长名称复制到剪贴板（不含路径）。"
+    IDS_SHORT_PATH_PLUGIN_DESCRIPTION "复制短路径(&S)"
     IDS_SHORT_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的短路径到剪切板。"
-    IDS_LONG_PATH_PLUGIN_DESCRIPTION "复制&长路径"
+                            "将文件/文件夹的短路径复制到剪切板。"
+    IDS_LONG_PATH_PLUGIN_DESCRIPTION "复制长路径(&L)"
 END
 
 STRINGTABLE
 BEGIN
     IDS_LONG_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的长路径到剪切板。"
+                            "将文件/文件夹的长路径复制到剪切板。"
     IDS_LONG_UNC_PATH_PLUGIN_DESCRIPTION "复制长 &UNC 路径"
     IDS_LONG_UNC_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的长 UNC（网络共享）路径到剪切板。若不存在网络路径，则复制长路径。"
-    IDS_INTERNET_PATH_PLUGIN_DESCRIPTION "复制&互联网路径"
+                            "将文件/文件夹的长 UNC（网络共享）路径复制到剪切板。若不存在网络路径，则复制长路径。"
+    IDS_INTERNET_PATH_PLUGIN_DESCRIPTION "复制互联网路径(&I)"
     IDS_INTERNET_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的 URI 格式路径到剪切板。"
+                            "将文件/文件夹的 URI 格式路径复制到剪切板。"
     IDS_UNIX_PATH_PLUGIN_DESCRIPTION "复制 Uni&x 路径"
     IDS_UNIX_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的路径到剪切板，使用正斜杠代替反斜杠。"
+                            "将文件/文件夹的路径复制到剪切板，使用正斜杠代替反斜杠。"
     IDS_CYGWIN_PATH_PLUGIN_DESCRIPTION "复制 Cy&gwin 路径"
     IDS_CYGWIN_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的路径到剪切板，使用 Cygwin 工具可识别的格式。"
+                            "将文件/文件夹的路径复制到剪切板，使用 Cygwin 工具可识别的格式。"
     IDS_DEFAULT_PLUGIN_DESCRIPTION "复制文件/文件夹&路径"
     IDS_SHORT_UNC_PATH_PLUGIN_DESCRIPTION "复制短 UN&C 路径"
     IDS_SHORT_UNC_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的短 UNC（网络共享）路径到剪切板。若不存在网络路径，则复制短路径。"
+                            "将文件/文件夹的短 UNC（网络共享）路径复制到剪切板。若不存在网络路径，则复制短路径。"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_LONG_FOLDER_PLUGIN_DESCRIPTION "复制父&目录长路径"
+    IDS_LONG_FOLDER_PLUGIN_DESCRIPTION "复制上级目录长路径(&F)"
     IDS_LONG_FOLDER_PLUGIN_HINT 
-                            "复制文件/文件夹的父目录的长路径到剪切板。"
-    IDS_SHORT_FOLDER_PLUGIN_DESCRIPTION "复制父&目录短路径"
+                            "将文件/文件夹上级目录的长路径复制到剪切板。"
+    IDS_SHORT_FOLDER_PLUGIN_DESCRIPTION "复制上级目录短路径(&O)"
     IDS_SHORT_FOLDER_PLUGIN_HINT 
-                            "复制文件/文件夹的父目录的短路径到剪切板。"
+                            "将文件/文件夹上级目录的短路径复制到剪切板。"
     IDS_SHORT_UNC_FOLDER_PLUGIN_DESCRIPTION 
-                            "复制 UNC 父&目录短路径"
+                            "复制 UNC 上级目录短路径(&D)"
     IDS_SHORT_UNC_FOLDER_PLUGIN_HINT 
-                            "复制文件/文件夹的父目录的 UNC（网络共享）短路径到剪切板。若不存在网络路径，则复制父目录短路径。"
-    IDS_LONG_UNC_FOLDER_PLUGIN_DESCRIPTION "复制 UNC 父&目录长路径"
+                            "将文件/文件夹上级目录的 UNC（网络共享）短路径复制到剪切板。若不存在网络路径，则复制上级目录短路径。"
+    IDS_LONG_UNC_FOLDER_PLUGIN_DESCRIPTION "复制 UNC 父目录长路径(&E)"
     IDS_LONG_UNC_FOLDER_PLUGIN_HINT 
-                            "复制文件/文件夹的父目录的 UNC（网络共享）长路径到剪切板。若不存在网络路径，则复制父目录长路径。"
+                            "将文件/文件夹上级目录的 UNC（网络共享）长路径复制到剪切板。若不存在网络路径，则复制上级目录长路径。"
     IDS_PCC_SETTINGS_DESCRIPTION "设置..."
     IDS_PCC_SETTINGS_HINT   "打开设置窗口配置此右键菜单。"
     IDS_SETTINGS_APP_FILE_NAME "PathCopyCopySettings.exe"
     IDS_REDUNDANT_WORD_COPY "复制"
-    IDS_ANDROGYNOUS_NAME_PLUGIN_DESCRIPTION "复制&名称"
-    IDS_ANDROGYNOUS_PATH_PLUGIN_DESCRIPTION "复制&路径"
+    IDS_ANDROGYNOUS_NAME_PLUGIN_DESCRIPTION "复制名称(&N)"
+    IDS_ANDROGYNOUS_PATH_PLUGIN_DESCRIPTION "复制路径(&P)"
     IDS_ANDROGYNOUS_UNC_PATH_PLUGIN_DESCRIPTION "复制 &UNC 路径"
-    IDS_ANDROGYNOUS_FOLDER_PLUGIN_DESCRIPTION "复制父&目录路径"
+    IDS_ANDROGYNOUS_FOLDER_PLUGIN_DESCRIPTION "复制上级目录路径(&F)"
 END
 
 STRINGTABLE
 BEGIN
     IDS_ANDROGYNOUS_UNC_FOLDER_PLUGIN_DESCRIPTION 
-                            "复制 UNC 父&目录路径"
+                            "复制 UNC 上级目录路径(&D)"
     IDS_WSL_PATH_PLUGIN_DESCRIPTION "复制 &WSL 路径"
     IDS_WSL_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的 WSL (Windows Subsystem for Linux) 格式路径到剪切板。"
+                            "将文件/文件夹的 WSL (Windows Subsystem for Linux) 格式路径复制到剪切板。"
     IDS_SAMBA_PATH_PLUGIN_DESCRIPTION "复制 S&amba 路径"
     IDS_SAMBA_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的 Samba 格式路径到剪切板。"
+                            "将文件/文件夹的 Samba 格式路径复制到剪切板。"
     IDS_MSYS_PATH_PLUGIN_DESCRIPTION "复制 MS&YS/MSYS2 路径"
     IDS_MSYS_PATH_PLUGIN_HINT 
-                            "复制文件/文件夹的 MSYS/MSYS2 格式路径到剪切板。"
+                            "将复制文件/文件夹的 MSYS/MSYS2 格式路径复制到剪切板。"
     IDS_INVALIDPIPELINE     "<< 无效的自定义命令 >>"
     IDS_INVALIDPIPELINE_LOOP_DETECTED 
                             "<< 检测到自定义命令元素存在循环 >>"
     IDS_INVALIDPIPELINE_POSSIBLE_DOWNGRADE 
-                            "<< 无效的自定义命令元素（可能降级） >>"
+                            "<< 无效的自定义命令元素（可能是降级安装所致） >>"
     IDS_INVALIDPIPELINE_BASE_COMMAND_NOT_FOUND "<< 未找到基本命令 >>"
 END
 
@@ -123,7 +123,7 @@ LANGUAGE LANG_FRENCH, SUBLANG_FRENCH_CANADIAN
 #pragma code_page(1252)
 
 /////////////////////////////////////////////////////////////////////////////
-// Chinese (Simplified, PRC) resources
+// Chinese (Simplified) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_CHS)
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
@@ -158,7 +158,7 @@ END
 /////////////////////////////////////////////////////////////////////////////
 
 
-#endif    // Chinese (Simplified, PRC) resources
+#endif    // Chinese (Simplified) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/PathCopyCopy/localization/PathCopyCopyLocalization_zh/rsrc/PathCopyCopyLocalization_zh.rc
+++ b/PathCopyCopy/localization/PathCopyCopyLocalization_zh/rsrc/PathCopyCopyLocalization_zh.rc
@@ -39,47 +39,47 @@ BEGIN
                             "将文件/文件夹的长名称复制到剪贴板（不含路径）。"
     IDS_SHORT_PATH_PLUGIN_DESCRIPTION "复制短路径(&S)"
     IDS_SHORT_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的短路径复制到剪切板。"
+                            "将文件/文件夹的短路径复制到剪贴板。"
     IDS_LONG_PATH_PLUGIN_DESCRIPTION "复制长路径(&L)"
 END
 
 STRINGTABLE
 BEGIN
     IDS_LONG_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的长路径复制到剪切板。"
+                            "将文件/文件夹的长路径复制到剪贴板。"
     IDS_LONG_UNC_PATH_PLUGIN_DESCRIPTION "复制长 &UNC 路径"
     IDS_LONG_UNC_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的长 UNC（网络共享）路径复制到剪切板。若不存在网络路径，则复制长路径。"
+                            "将文件/文件夹的长 UNC（网络共享）路径复制到剪贴板。若不存在网络路径，则复制长路径。"
     IDS_INTERNET_PATH_PLUGIN_DESCRIPTION "复制互联网路径(&I)"
     IDS_INTERNET_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的 URI 格式路径复制到剪切板。"
+                            "将文件/文件夹的 URI 格式路径复制到剪贴板。"
     IDS_UNIX_PATH_PLUGIN_DESCRIPTION "复制 Uni&x 路径"
     IDS_UNIX_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的路径复制到剪切板，使用正斜杠代替反斜杠。"
+                            "将文件/文件夹的路径复制到剪贴板，使用正斜杠代替反斜杠。"
     IDS_CYGWIN_PATH_PLUGIN_DESCRIPTION "复制 Cy&gwin 路径"
     IDS_CYGWIN_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的路径复制到剪切板，使用 Cygwin 工具可识别的格式。"
+                            "将文件/文件夹的路径复制到剪贴板，使用 Cygwin 工具可识别的格式。"
     IDS_DEFAULT_PLUGIN_DESCRIPTION "复制文件/文件夹&路径"
     IDS_SHORT_UNC_PATH_PLUGIN_DESCRIPTION "复制短 UN&C 路径"
     IDS_SHORT_UNC_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的短 UNC（网络共享）路径复制到剪切板。若不存在网络路径，则复制短路径。"
+                            "将文件/文件夹的短 UNC（网络共享）路径复制到剪贴板。若不存在网络路径，则复制短路径。"
 END
 
 STRINGTABLE
 BEGIN
     IDS_LONG_FOLDER_PLUGIN_DESCRIPTION "复制上级目录长路径(&F)"
     IDS_LONG_FOLDER_PLUGIN_HINT 
-                            "将文件/文件夹上级目录的长路径复制到剪切板。"
+                            "将文件/文件夹上级目录的长路径复制到剪贴板。"
     IDS_SHORT_FOLDER_PLUGIN_DESCRIPTION "复制上级目录短路径(&O)"
     IDS_SHORT_FOLDER_PLUGIN_HINT 
-                            "将文件/文件夹上级目录的短路径复制到剪切板。"
+                            "将文件/文件夹上级目录的短路径复制到剪贴板。"
     IDS_SHORT_UNC_FOLDER_PLUGIN_DESCRIPTION 
                             "复制 UNC 上级目录短路径(&D)"
     IDS_SHORT_UNC_FOLDER_PLUGIN_HINT 
-                            "将文件/文件夹上级目录的 UNC（网络共享）短路径复制到剪切板。若不存在网络路径，则复制上级目录短路径。"
+                            "将文件/文件夹上级目录的 UNC（网络共享）短路径复制到剪贴板。若不存在网络路径，则复制上级目录短路径。"
     IDS_LONG_UNC_FOLDER_PLUGIN_DESCRIPTION "复制 UNC 父目录长路径(&E)"
     IDS_LONG_UNC_FOLDER_PLUGIN_HINT 
-                            "将文件/文件夹上级目录的 UNC（网络共享）长路径复制到剪切板。若不存在网络路径，则复制上级目录长路径。"
+                            "将文件/文件夹上级目录的 UNC（网络共享）长路径复制到剪贴板。若不存在网络路径，则复制上级目录长路径。"
     IDS_PCC_SETTINGS_DESCRIPTION "设置..."
     IDS_PCC_SETTINGS_HINT   "打开设置窗口配置此右键菜单。"
     IDS_SETTINGS_APP_FILE_NAME "PathCopyCopySettings.exe"
@@ -96,13 +96,13 @@ BEGIN
                             "复制 UNC 上级目录路径(&D)"
     IDS_WSL_PATH_PLUGIN_DESCRIPTION "复制 &WSL 路径"
     IDS_WSL_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的 WSL (Windows Subsystem for Linux) 格式路径复制到剪切板。"
+                            "将文件/文件夹的 WSL (Windows Subsystem for Linux) 格式路径复制到剪贴板。"
     IDS_SAMBA_PATH_PLUGIN_DESCRIPTION "复制 S&amba 路径"
     IDS_SAMBA_PATH_PLUGIN_HINT 
-                            "将文件/文件夹的 Samba 格式路径复制到剪切板。"
+                            "将文件/文件夹的 Samba 格式路径复制到剪贴板。"
     IDS_MSYS_PATH_PLUGIN_DESCRIPTION "复制 MS&YS/MSYS2 路径"
     IDS_MSYS_PATH_PLUGIN_HINT 
-                            "将复制文件/文件夹的 MSYS/MSYS2 格式路径复制到剪切板。"
+                            "将复制文件/文件夹的 MSYS/MSYS2 格式路径复制到剪贴板。"
     IDS_INVALIDPIPELINE     "<< 无效的自定义命令 >>"
     IDS_INVALIDPIPELINE_LOOP_DETECTED 
                             "<< 检测到自定义命令元素存在循环 >>"

--- a/PathCopyCopySettings/Properties/Resources.zh-CN.resx
+++ b/PathCopyCopySettings/Properties/Resources.zh-CN.resx
@@ -382,13 +382,13 @@ Shift + 单击，使此命令使用默认图标。
     <value>用 %20 替换路径中的所有空格字符</value>
   </data>
   <data name="PipelineElement_ExecutableWithFilelist_HelpText" xml:space="preserve">
-    <value>Instead of copying paths to the clipboard, save them to a filelist, then launch an executable on disk, passing the filelist as argument</value>
+    <value>不复制到剪贴板，而是将路径列表保存为文本文件，然后启动磁盘中的可执行程序，并将文本文件作为参数传递给该程序</value>
   </data>
   <data name="PipelineElement_Executable_HelpText" xml:space="preserve">
-    <value>Instead of copying paths to the clipboard, launch an executable on disk, passing the paths as arguments</value>
+    <value>不复制到剪贴板，而是启动磁盘中的可执行程序，并将路径列表作为参数传递给该程序</value>
   </data>
   <data name="PipelineElement_FindReplace_HelpText" xml:space="preserve">
-    <value>Replace every instance of a specific character string in the path with another</value>
+    <value>将路径中出现的所有指定字符串替换为指定内容</value>
   </data>
   <data name="PipelineElement_ForwardToBackslashes_HelpText" xml:space="preserve">
     <value>将路径中的每一个正斜杠 ( / ) 替换为反斜杠 ( / )</value>
@@ -424,16 +424,16 @@ Shift + 单击，使此命令使用默认图标。
     <value>https://github.com/clechasseur/pathcopycopy/blob/default/LICENSE</value>
   </data>
   <data name="PipelineElement_FollowSymlink" xml:space="preserve">
-    <value>Follow Symbolic Link</value>
+    <value>解析符号链接</value>
   </data>
   <data name="PipelineElement_FollowSymlink_HelpText" xml:space="preserve">
-    <value>Replace the path to a symbolic link with the path to its target</value>
+    <value>将符号链接的路径替换为其目标的路径</value>
   </data>
   <data name="PipelineElement_UnexpandEnvStrings" xml:space="preserve">
-    <value>Unexpand Environment Strings</value>
+    <value>展开环境变量字符串</value>
   </data>
   <data name="PipelineElement_UnexpandEnvStrings_HelpText" xml:space="preserve">
-    <value>Replace parts of the path with environment variable references, if possible (like %USERPROFILE%, etc.)</value>
+    <value>如果可能，将路径中出现的环境变量替换为其值 (例如 %USERPROFILE%)。</value>
   </data>
   <data name="PipelineElement_ApplyPipelinePlugin" xml:space="preserve">
     <value>使用基本命令</value>
@@ -445,40 +445,40 @@ Shift + 单击，使此命令使用默认图标。
     <value>（复制）</value>
   </data>
   <data name="PipelineElement_InjectDriveLabel" xml:space="preserve">
-    <value>Inject Drive Label</value>
+    <value>注入磁盘名称</value>
   </data>
   <data name="PipelineElement_InjectDriveLabel_HelpText" xml:space="preserve">
-    <value>Replace all instances of %DRIVELABEL% in the path with the drive's label</value>
+    <value>将路径出现的所有 %DRIVELABEL% 替换为磁盘名称</value>
   </data>
   <data name="PipelineElement_CopyNPathParts" xml:space="preserve">
-    <value>Copy # path parts (from beginning or end)</value>
+    <value>只复制 n 层路径 (从开头/末尾计)</value>
   </data>
   <data name="PipelineElement_CopyNPathParts_HelpText" xml:space="preserve">
-    <value>Keep only a certain number of path parts from the path, either from the beginning or the end</value>
+    <value>只保留路径中特定层数的部分，可以从前往后，也可以从后往前</value>
   </data>
   <data name="PipelineElement_DuplicateStackValue" xml:space="preserve">
-    <value>Duplicate Top Stack Value</value>
+    <value>复制堆栈顶层元素</value>
   </data>
   <data name="PipelineElement_DuplicateStackValue_HelpText" xml:space="preserve">
-    <value>Duplicate the top value on the stack</value>
+    <value>将堆栈最顶层的元素复制一份</value>
   </data>
   <data name="PipelineElement_PopFromStack" xml:space="preserve">
-    <value>Pop Value from Stack</value>
+    <value>从堆栈弹出元素</value>
   </data>
   <data name="PipelineElement_PopFromStack_HelpText" xml:space="preserve">
-    <value>Pop a value from the stack, possibly inserting it somewhere in the path</value>
+    <value>将元素从堆栈弹出，例如插入到路径中的某处</value>
   </data>
   <data name="PipelineElement_PushToStack" xml:space="preserve">
-    <value>Push Value to Stack</value>
+    <value>将元素推入堆栈</value>
   </data>
   <data name="PipelineElement_PushToStack_HelpText" xml:space="preserve">
-    <value>Push a value to the stack, possibly part of the path</value>
+    <value>将一个元素推入堆栈，可以是路径的一部分</value>
   </data>
   <data name="PipelineElement_SwapStackValues" xml:space="preserve">
-    <value>Swap Top Two Stack Values</value>
+    <value>交换堆栈顶层的两个元素</value>
   </data>
   <data name="PipelineElement_SwapStackValues_HelpText" xml:space="preserve">
-    <value>Swap the top two values on the stack</value>
+    <value>交换堆栈最上面的两个元素</value>
   </data>
   <data name="Language_English_DisplayName" xml:space="preserve">
     <value>英语 (English)</value>
@@ -511,7 +511,7 @@ Shift + 单击，使此命令使用默认图标。
     <value>选项：启动命令行</value>
   </data>
   <data name="PipelineElement_CommandLine_HelpText" xml:space="preserve">
-    <value>Instead of copying the paths to the clipboard, launch a command-line (executable &amp; arguments), including the paths in the arguments either directly or via a filelist</value>
+    <value>不复制到剪贴板，而是启动命令行（可执行程序+参数），并将路径列表或列表文件作为参数传递给该程序</value>
   </data>
   <data name="PipelineElement_RecursiveCopy" xml:space="preserve">
     <value>选项：递归复制路径</value>

--- a/PathCopyCopySettings/UI/Forms/AdvancedPipelinePluginForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/AdvancedPipelinePluginForm.zh-CN.resx
@@ -199,7 +199,7 @@
     <value>4</value>
   </data>
   <data name="ElementsLbl.Text" xml:space="preserve">
-    <value>&amp;元素：</value>
+    <value>元素(&amp;E):</value>
   </data>
   <data name="DeleteElementBtn.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -517,7 +517,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NameLbl.Text" xml:space="preserve">
-    <value>&amp;名称：</value>
+    <value>名称(&amp;N):</value>
   </data>
   <data name="ElementsLbl.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 48</value>

--- a/PathCopyCopySettings/UI/Forms/ImportPipelinePluginsForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/ImportPipelinePluginsForm.zh-CN.resx
@@ -150,7 +150,7 @@
     <value>已导入自定义命令</value>
   </data>
   <data name="CancelBtn.Text" xml:space="preserve">
-    <value>Cancel</value>
+    <value>取消</value>
   </data>
   <data name="&gt;&gt;CancelBtn.Name" xml:space="preserve">
     <value>CancelBtn</value>
@@ -244,7 +244,7 @@
     <value>$this</value>
   </data>
   <data name="OKBtn.Text" xml:space="preserve">
-    <value>OK</value>
+    <value>确定</value>
   </data>
   <data name="&gt;&gt;ChoosePipelinePluginsLbl.Name" xml:space="preserve">
     <value>ChoosePipelinePluginsLbl</value>

--- a/PathCopyCopySettings/UI/Forms/MainForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/MainForm.zh-CN.resx
@@ -136,7 +136,7 @@
     <value>4</value>
   </data>
   <data name="ApplyBtn.Text" xml:space="preserve">
-    <value>&amp;Apply</value>
+    <value>应用(&amp;A)</value>
   </data>
   <metadata name="MainToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>769, 18</value>
@@ -169,7 +169,7 @@
     <value>2</value>
   </data>
   <data name="OKBtn.Text" xml:space="preserve">
-    <value>OK</value>
+    <value>确定</value>
   </data>
   <data name="OKBtn.ToolTip" xml:space="preserve">
     <value>保存设置并关闭窗口</value>
@@ -199,7 +199,7 @@
     <value>3</value>
   </data>
   <data name="CancelBtn.Text" xml:space="preserve">
-    <value>&amp;Cancel</value>
+    <value>取消(&amp;C)</value>
   </data>
   <data name="CancelBtn.ToolTip" xml:space="preserve">
     <value>取消更改并关闭窗口</value>
@@ -232,7 +232,7 @@
     <value>10</value>
   </data>
   <data name="DuplicatePipelinePluginBtn.Text" xml:space="preserve">
-    <value>Dup&amp;licate</value>
+    <value>创建副本(&amp;L)</value>
   </data>
   <data name="DuplicatePipelinePluginBtn.ToolTip" xml:space="preserve">
     <value>创建选中自定义命令的副本</value>
@@ -286,7 +286,7 @@
     <value>8</value>
   </data>
   <data name="AddSeparatorBtn.Text" xml:space="preserve">
-    <value>&amp;分隔线</value>
+    <value>添加分隔线(&amp;S)</value>
   </data>
   <data name="AddSeparatorBtn.ToolTip" xml:space="preserve">
     <value>在选中的命令下方创建分隔线</value>
@@ -316,7 +316,7 @@
     <value>14</value>
   </data>
   <data name="ImportPipelinePluginsBtn.Text" xml:space="preserve">
-    <value>&amp;Import...</value>
+    <value>导入(&amp;I)...</value>
   </data>
   <data name="ImportPipelinePluginsBtn.ToolTip" xml:space="preserve">
     <value>从硬盘文件导入自定义命令</value>
@@ -346,7 +346,7 @@
     <value>13</value>
   </data>
   <data name="ExportPipelinePluginsBtn.Text" xml:space="preserve">
-    <value>导&amp;出...</value>
+    <value>导出(&amp;P)...</value>
   </data>
   <data name="ExportPipelinePluginsBtn.ToolTip" xml:space="preserve">
     <value>将选定的自定义命令导出到磁盘中</value>
@@ -400,7 +400,7 @@
     <value>11</value>
   </data>
   <data name="RemovePluginBtn.Text" xml:space="preserve">
-    <value>&amp;Remove</value>
+    <value>删除(&amp;R)</value>
   </data>
   <data name="RemovePluginBtn.ToolTip" xml:space="preserve">
     <value>删除选中的自定义命令或分隔线</value>
@@ -430,7 +430,7 @@
     <value>9</value>
   </data>
   <data name="EditPipelinePluginBtn.Text" xml:space="preserve">
-    <value>&amp;编辑...</value>
+    <value>编辑(&amp;E)...</value>
   </data>
   <data name="EditPipelinePluginBtn.ToolTip" xml:space="preserve">
     <value>编辑选中的自定义命令</value>
@@ -460,7 +460,7 @@
     <value>7</value>
   </data>
   <data name="AddPipelinePluginBtn.Text" xml:space="preserve">
-    <value>&amp;新建...</value>
+    <value>新建(&amp;N)...</value>
   </data>
   <data name="AddPipelinePluginBtn.ToolTip" xml:space="preserve">
     <value>创建一个新的自定义命令</value>
@@ -514,7 +514,7 @@
     <value>5</value>
   </data>
   <data name="MovePluginDownBtn.Text" xml:space="preserve">
-    <value>&amp;下移</value>
+    <value>下移(&amp;D)</value>
   </data>
   <data name="MovePluginDownBtn.ToolTip" xml:space="preserve">
     <value>下移选中的命令</value>
@@ -544,7 +544,7 @@
     <value>4</value>
   </data>
   <data name="MovePluginUpBtn.Text" xml:space="preserve">
-    <value>&amp;上移</value>
+    <value>上移(&amp;U)</value>
   </data>
   <data name="MovePluginUpBtn.ToolTip" xml:space="preserve">
     <value>上移选中的命令</value>
@@ -718,10 +718,10 @@
     <value>14</value>
   </data>
   <data name="RecursiveCopyChk.Text" xml:space="preserve">
-    <value>递归&amp;复制路径</value>
+    <value>递归复制路径(&amp;U)</value>
   </data>
   <data name="RecursiveCopyChk.ToolTip" xml:space="preserve">
-    <value>Recurse into subdirectories when copying paths</value>
+    <value>复制路径时递归其子目录内容</value>
   </data>
   <data name="&gt;&gt;RecursiveCopyChk.Name" xml:space="preserve">
     <value>RecursiveCopyChk</value>
@@ -781,7 +781,7 @@
     <value>19</value>
   </data>
   <data name="LanguageLbl.Text" xml:space="preserve">
-    <value>语&amp;言：</value>
+    <value>语言(&amp;G):</value>
   </data>
   <data name="&gt;&gt;LanguageLbl.Name" xml:space="preserve">
     <value>LanguageLbl</value>
@@ -808,7 +808,7 @@
     <value>15</value>
   </data>
   <data name="TrueLnkPathsChk.Text" xml:space="preserve">
-    <value>复制快捷&amp;方式 (.lnk) 文件本身的路径</value>
+    <value>复制快捷方式 (.lnk) 文件本身的路径(&amp;O)</value>
   </data>
   <data name="TrueLnkPathsChk.ToolTip" xml:space="preserve">
     <value>复制快捷方式 (.lnk) 文件的路径时，复制快捷方式文件本身的路径，而不是目标文件的路径。</value>
@@ -841,7 +841,7 @@
     <value>11</value>
   </data>
   <data name="UsePreviewModeInMainMenuChk.Text" xml:space="preserve">
-    <value>...以及在主&amp;菜单</value>
+    <value>...以及在主菜单(&amp;N)</value>
   </data>
   <data name="UsePreviewModeInMainMenuChk.ToolTip" xml:space="preserve">
     <value>在右键菜单中显示命令的预览</value>
@@ -871,7 +871,7 @@
     <value>5</value>
   </data>
   <data name="AppendSepForDirChk.Text" xml:space="preserve">
-    <value>为目录路径添加&amp;分隔符</value>
+    <value>为目录路径添加分隔符(&amp;E)</value>
   </data>
   <data name="AppendSepForDirChk.ToolTip" xml:space="preserve">
     <value>当复制目录路径时，在路径末尾添加一个分隔符（例如：\ 或 /）。</value>
@@ -901,10 +901,10 @@
     <value>7</value>
   </data>
   <data name="UseFQDNChk.Text" xml:space="preserve">
-    <value>Use &amp;fully-qualified domain names when copying UNC paths</value>
+    <value>复制 UNC 路径时使用绝对域名(&amp;F)</value>
   </data>
   <data name="UseFQDNChk.ToolTip" xml:space="preserve">
-    <value>Use fully-qualified domain names (e.g. FQDN) when copying UNC paths</value>
+    <value>复制 UNC 路径的时候使用完整的绝对域名 (FQDN)</value>
   </data>
   <data name="&gt;&gt;UseFQDNChk.Name" xml:space="preserve">
     <value>UseFQDNChk</value>
@@ -934,7 +934,7 @@
     <value>1</value>
   </data>
   <data name="AreQuotesOptionalChk.Text" xml:space="preserve">
-    <value>...仅当路径包含&amp;空格时</value>
+    <value>...仅当路径包含空格时(&amp;S)</value>
   </data>
   <data name="AreQuotesOptionalChk.ToolTip" xml:space="preserve">
     <value>是否在路径中包含空格时使用引号包围路径</value>
@@ -1030,7 +1030,7 @@
     <value>4</value>
   </data>
   <data name="EncodeURICharsChk.Text" xml:space="preserve">
-    <value>...以及所有无&amp;效的 URI 字符 (例 %xx)</value>
+    <value>...以及所有无效的 URI 字符 (例 %xx) (&amp;V)</value>
   </data>
   <data name="EncodeURICharsChk.ToolTip" xml:space="preserve">
     <value>将复制路径中所有无效的字符用百分比编码 ( %xx ) 代替。</value>
@@ -1060,7 +1060,7 @@
     <value>3</value>
   </data>
   <data name="EncodeURIWhitespaceChk.Text" xml:space="preserve">
-    <value>对&amp;空白字符使用百分比编码 (例 %20)</value>
+    <value>对空白字符使用百分比编码 (例 %20) (&amp;W)</value>
   </data>
   <data name="EncodeURIWhitespaceChk.ToolTip" xml:space="preserve">
     <value>用 %20 替换路径中的所有空白字符</value>
@@ -1090,7 +1090,7 @@
     <value>13</value>
   </data>
   <data name="CopyOnSameLineChk.Text" xml:space="preserve">
-    <value>将多&amp;个路径复制为同一行</value>
+    <value>将多个路径复制为同一行(&amp;T)</value>
   </data>
   <data name="CopyOnSameLineChk.ToolTip" xml:space="preserve">
     <value>当复制多个选定文件/文件夹的路径时，将它们全部复制在同一行（用空格隔开），而不是复制在不同的行上（用换行符隔开）</value>
@@ -1120,7 +1120,7 @@
     <value>12</value>
   </data>
   <data name="DropRedundantWordsChk.Text" xml:space="preserve">
-    <value>去掉&amp;子菜单中 "复制" 或 "长/短" 等多余词语</value>
+    <value>去掉子菜单中 "复制" 或 "长/短" 等多余词语 (&amp;R)</value>
   </data>
   <data name="DropRedundantWordsChk.ToolTip" xml:space="preserve">
     <value>在子菜单中显示命令时，去掉一些多余的词语</value>
@@ -1150,7 +1150,7 @@
     <value>10</value>
   </data>
   <data name="UsePreviewModeChk.Text" xml:space="preserve">
-    <value>右键菜单直接显示命令的&amp;输出结果</value>
+    <value>右键菜单直接显示命令的输出结果(&amp;P)</value>
   </data>
   <data name="UsePreviewModeChk.ToolTip" xml:space="preserve">
     <value>打开右键菜单时，直接显示复制的路径，不显示命令名。</value>
@@ -1180,7 +1180,7 @@
     <value>9</value>
   </data>
   <data name="UseIconForSubmenuChk.Text" xml:space="preserve">
-    <value>显示&amp;右键菜单子菜单的图标</value>
+    <value>显示右键菜单子菜单的图标(&amp;I)</value>
   </data>
   <data name="UseIconForSubmenuChk.ToolTip" xml:space="preserve">
     <value>在右键菜单的子菜单前添加 Path Copy Copy 图标</value>
@@ -1240,7 +1240,7 @@
     <value>18</value>
   </data>
   <data name="EnableSoftwareUpdateChk.Text" xml:space="preserve">
-    <value>自&amp;动检查更新</value>
+    <value>自动检查更新(&amp;Y)</value>
   </data>
   <data name="EnableSoftwareUpdateChk.ToolTip" xml:space="preserve">
     <value>自动检查 Path Copy Copy 的新版本，并在其发布时提供</value>
@@ -1270,7 +1270,7 @@
     <value>8</value>
   </data>
   <data name="AlwaysShowSubmenuChk.Text" xml:space="preserve">
-    <value>总&amp;是显示子菜单</value>
+    <value>总是显示子菜单(&amp;L)</value>
   </data>
   <data name="AlwaysShowSubmenuChk.ToolTip" xml:space="preserve">
     <value>始终在 "右键菜单" 中显示 "Path Copy Copy " 子菜单（否则，只有在按住 Shift 键打开右键菜单时才显示）</value>
@@ -1300,7 +1300,7 @@
     <value>6</value>
   </data>
   <data name="HiddenSharesChk.Text" xml:space="preserve">
-    <value>复制 UNC 路径时使用&amp;隐藏共享</value>
+    <value>复制 UNC 路径时使用隐藏共享(&amp;H)</value>
   </data>
   <data name="HiddenSharesChk.ToolTip" xml:space="preserve">
     <value>Consider hidden shares (shares ending with the $ character, including administrative shares like \\server\C$) when copying UNC paths</value>
@@ -1330,7 +1330,7 @@
     <value>0</value>
   </data>
   <data name="AddQuotesChk.Text" xml:space="preserve">
-    <value>Add &amp;quotes around copied paths</value>
+    <value>在复制后的路径两侧添加引号(&amp;Q)</value>
   </data>
   <data name="AddQuotesChk.ToolTip" xml:space="preserve">
     <value>将所有复制的路径用引号 ( " )括起来</value>
@@ -1360,7 +1360,7 @@
     <value>0</value>
   </data>
   <data name="MiscOptionsPage.Text" xml:space="preserve">
-    <value>Options</value>
+    <value>选项</value>
   </data>
   <data name="&gt;&gt;MiscOptionsPage.Name" xml:space="preserve">
     <value>MiscOptionsPage</value>
@@ -1537,7 +1537,7 @@
     <value>4</value>
   </data>
   <data name="LicenseExplanationLbl.Text" xml:space="preserve">
-    <value>Path Copy Copy 是一款基于 MIT 协议的免费软件。详情信息请访问</value>
+    <value>Path Copy Copy 是一款 MIT 协议发行的免费软件。详情信息请访问</value>
   </data>
   <data name="LicenseExplanationLbl.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>BottomCenter</value>
@@ -1570,7 +1570,7 @@
     <value>5</value>
   </data>
   <data name="LicenseTxtLinkLbl.Text" xml:space="preserve">
-    <value>LICENSE</value>
+    <value>LICENSE (授权许可文件)</value>
   </data>
   <data name="LicenseTxtLinkLbl.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>TopCenter</value>
@@ -1742,7 +1742,7 @@
     <value>1</value>
   </data>
   <data name="ExportUserSettingsBtn.Text" xml:space="preserve">
-    <value>导&amp;出设置...</value>
+    <value>导出设置(&amp;X)...</value>
   </data>
   <data name="ExportUserSettingsBtn.ToolTip" xml:space="preserve">
     <value>导出所有设置到本地磁盘</value>

--- a/PathCopyCopySettings/UI/Forms/MainForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/MainForm.zh-CN.resx
@@ -1273,7 +1273,7 @@
     <value>总是显示子菜单(&amp;L)</value>
   </data>
   <data name="AlwaysShowSubmenuChk.ToolTip" xml:space="preserve">
-    <value>始终在 "右键菜单" 中显示 "Path Copy Copy " 子菜单（否则，只有在按住 Shift 键打开右键菜单时才显示）</value>
+    <value>始终在右键菜单中显示“Path Copy Copy”子菜单（否则，只有在按住 Shift 键打开右键菜单时才显示）</value>
   </data>
   <data name="&gt;&gt;AlwaysShowSubmenuChk.Name" xml:space="preserve">
     <value>AlwaysShowSubmenuChk</value>
@@ -1537,7 +1537,7 @@
     <value>4</value>
   </data>
   <data name="LicenseExplanationLbl.Text" xml:space="preserve">
-    <value>Path Copy Copy 是一款 MIT 协议发行的免费软件。详情信息请访问</value>
+    <value>Path Copy Copy 是一款依 MIT 协议发行的免费软件。详情请访问</value>
   </data>
   <data name="LicenseExplanationLbl.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>BottomCenter</value>

--- a/PathCopyCopySettings/UI/Forms/PipelinePluginForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/PipelinePluginForm.zh-CN.resx
@@ -190,7 +190,7 @@
     <value>0</value>
   </data>
   <data name="ReplaceLbl.Text" xml:space="preserve">
-    <value>&amp;替换为：</value>
+    <value>替换为(&amp;R):</value>
   </data>
   <data name="DecorationsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>362, 161</value>
@@ -205,7 +205,7 @@
     <value>OptionsGroupBox</value>
   </data>
   <data name="ForwardToBackslashesRadio.Text" xml:space="preserve">
-    <value>将所有正斜杠 ( / ) 改为&amp;反斜杠 ( \ )</value>
+    <value>将所有正斜杠 ( / ) 改为反斜杠 ( \ ) (&amp;B)</value>
   </data>
   <data name="EncodeURICharsChk.Location" type="System.Drawing.Point, System.Drawing">
     <value>25, 134</value>
@@ -355,7 +355,7 @@
     <value>UnexpandEnvStringsChk</value>
   </data>
   <data name="OptionalQuotesChk.Text" xml:space="preserve">
-    <value>...仅当包含&amp;空格时</value>
+    <value>...仅当包含空格时(&amp;P)</value>
   </data>
   <data name="&gt;&gt;SwitchBtn.Name" xml:space="preserve">
     <value>SwitchBtn</value>
@@ -370,13 +370,13 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="FindLbl.Text" xml:space="preserve">
-    <value>查找 &amp;what:</value>
+    <value>查找内容(&amp;W):</value>
   </data>
   <data name="&gt;&gt;ForwardToBackslashesRadio.Name" xml:space="preserve">
     <value>ForwardToBackslashesRadio</value>
   </data>
   <data name="IgnoreCaseChk.Text" xml:space="preserve">
-    <value>&amp;忽略大小写</value>
+    <value>忽略大小写(&amp;I)</value>
   </data>
   <data name="&gt;&gt;CopyOnSameLineChk.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -424,7 +424,7 @@
     <value>WithFilelistChk</value>
   </data>
   <data name="WithFilelistChk.Text" xml:space="preserve">
-    <value>...并将路径保存在一个文件列表中，而不是&amp;直接传给他们。</value>
+    <value>...并将路径保存在一个文件列表中，而不是直接传给他们(&amp;D)</value>
   </data>
   <data name="BaseCommandLbl.Size" type="System.Drawing.Size, System.Drawing">
     <value>314, 13</value>
@@ -478,7 +478,7 @@
     <value>SlashesGroupBox</value>
   </data>
   <data name="CopyOnSameLineChk.Text" xml:space="preserve">
-    <value>复&amp;制多个路径到同一行</value>
+    <value>复制多个路径到同一行(&amp;Y)</value>
   </data>
   <data name="&gt;&gt;FindReplaceGroupBox.Parent" xml:space="preserve">
     <value>OptionsPage</value>
@@ -508,7 +508,7 @@
     <value>True</value>
   </data>
   <data name="EncodeURIWhitespaceChk.Text" xml:space="preserve">
-    <value>对空&amp;格使用百分号编码（例 %20）</value>
+    <value>对空格使用百分号编码 (如 %20) (&amp;H)</value>
   </data>
   <data name="&gt;&gt;NameLbl.ZOrder" xml:space="preserve">
     <value>6</value>
@@ -592,7 +592,7 @@
     <value>5</value>
   </data>
   <data name="UseRegexChk.Text" xml:space="preserve">
-    <value>使用正&amp;则表达式</value>
+    <value>使用正则表达式(&amp;E)</value>
   </data>
   <data name="&gt;&gt;ExecutableTxt.Parent" xml:space="preserve">
     <value>OptionsGroupBox</value>
@@ -622,7 +622,7 @@
     <value>3</value>
   </data>
   <data name="NoSlashesChangeRadio.Text" xml:space="preserve">
-    <value>不改变&amp;斜杠</value>
+    <value>不改变斜杠(&amp;S)</value>
   </data>
   <data name="ExecutableTxt.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -829,7 +829,7 @@
     <value>6, 173</value>
   </data>
   <data name="TestRegexBtn.Text" xml:space="preserve">
-    <value>&amp;测试...</value>
+    <value>测试(&amp;T)...</value>
   </data>
   <data name="&gt;&gt;OptionalQuotesChk.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -964,7 +964,7 @@
     <value>PipelinePluginForm</value>
   </data>
   <data name="EncodeURICharsChk.Text" xml:space="preserve">
-    <value>...以及&amp;所有无效 URI 字符 (例 %xx)</value>
+    <value>...以及所有无效 URI 字符 (例 %xx) (&amp;V)</value>
   </data>
   <data name="OptionsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>362, 143</value>
@@ -982,7 +982,7 @@
     <value />
   </data>
   <data name="LaunchExecutableChk.Text" xml:space="preserve">
-    <value>&amp;将路径作为参数启动可执行文件，不复制到剪贴板。</value>
+    <value>将路径作为参数启动可执行文件，不复制到剪贴板(&amp;L)</value>
   </data>
   <data name="RemoveExtChk.Size" type="System.Drawing.Size, System.Drawing">
     <value>130, 17</value>
@@ -991,7 +991,7 @@
     <value>138, 17</value>
   </data>
   <data name="ExecutableLbl.Text" xml:space="preserve">
-    <value>可&amp;执行文件：</value>
+    <value>可执行文件(&amp;x):</value>
   </data>
   <data name="&gt;&gt;CopyOnSameLineChk.Name" xml:space="preserve">
     <value>CopyOnSameLineChk</value>
@@ -1033,7 +1033,7 @@
     <value>$this</value>
   </data>
   <data name="BackToForwardSlashesRadio.Text" xml:space="preserve">
-    <value>将所有的反斜杠改为&amp;正斜杠</value>
+    <value>将所有的反斜杠改为正斜杠(&amp;F)</value>
   </data>
   <data name="&gt;&gt;OKBtn.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1114,10 +1114,10 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="RecursiveCopyChk.Text" xml:space="preserve">
-    <value>递&amp;归复制路径</value>
+    <value>递归复制路径(&amp;U)</value>
   </data>
   <data name="QuotesChk.Text" xml:space="preserve">
-    <value>用&amp;引号把路径引起来</value>
+    <value>用引号把路径引起来(&amp;Q)</value>
   </data>
   <data name="&gt;&gt;NameTxt.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1309,10 +1309,10 @@
     <value>True</value>
   </data>
   <data name="NameLbl.Text" xml:space="preserve">
-    <value>&amp;名称：</value>
+    <value>名称(&amp;N):</value>
   </data>
   <data name="RemoveExtChk.Text" xml:space="preserve">
-    <value>移除文件扩展&amp;名</value>
+    <value>移除文件扩展名(&amp;O)</value>
   </data>
   <data name="WithFilelistChk.Size" type="System.Drawing.Size, System.Drawing">
     <value>306, 17</value>
@@ -1327,7 +1327,7 @@
     <value>ExecutableLbl</value>
   </data>
   <data name="UnexpandEnvStringsChk.Text" xml:space="preserve">
-    <value>如果可以，使用环&amp;境变量替换部分路径</value>
+    <value>如果可以，使用环境变量替换部分路径(&amp;N)</value>
   </data>
   <data name="ExecutableTxt.Size" type="System.Drawing.Size, System.Drawing">
     <value>184, 20</value>

--- a/PathCopyCopySettings/UI/Forms/RegexTesterForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/RegexTesterForm.zh-CN.resx
@@ -202,7 +202,7 @@
     <value>InvalidNoticeLbl</value>
   </data>
   <data name="IgnoreCaseChk.Text" xml:space="preserve">
-    <value>&amp;忽略大小写</value>
+    <value>忽略大小写(&amp;I)</value>
   </data>
   <data name="ParamsGroupBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -274,7 +274,7 @@
     <value>2</value>
   </data>
   <data name="SampleLbl.Text" xml:space="preserve">
-    <value>&amp;示例：</value>
+    <value>示例(&amp;S):</value>
   </data>
   <data name="InvalidNoticeLbl.Size" type="System.Drawing.Size, System.Drawing">
     <value>152, 13</value>
@@ -307,7 +307,7 @@
     <value>3</value>
   </data>
   <data name="ReplacementLbl.Text" xml:space="preserve">
-    <value>&amp;替换表达式：</value>
+    <value>替换表达式(&amp;R):</value>
   </data>
   <data name="&gt;&gt;RegexSyntaxHelpLbl2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -598,7 +598,7 @@
     <value>Bottom, Right</value>
   </data>
   <data name="TestBtn.Text" xml:space="preserve">
-    <value>&amp;Test</value>
+    <value>Test(&amp;T)</value>
   </data>
   <data name="InvalidNoticeLbl.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 98</value>
@@ -607,7 +607,7 @@
     <value>0</value>
   </data>
   <data name="RegexLbl.Text" xml:space="preserve">
-    <value>正则&amp;表达式：</value>
+    <value>正则表达式(&amp;X):</value>
   </data>
   <data name="&gt;&gt;IgnoreCaseChk.Name" xml:space="preserve">
     <value>IgnoreCaseChk</value>

--- a/PathCopyCopySettings/UI/Forms/SoftwareUpdateForm.zh-CN.resx
+++ b/PathCopyCopySettings/UI/Forms/SoftwareUpdateForm.zh-CN.resx
@@ -298,7 +298,7 @@
     <value>$this</value>
   </data>
   <data name="CloseBtn.Text" xml:space="preserve">
-    <value>&amp;关闭</value>
+    <value>关闭(&amp;C)</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Path Copy Copy 有新更新</value>
@@ -352,7 +352,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="IgnoreUpdateBtn.Text" xml:space="preserve">
-    <value>&amp;忽略此版本更新</value>
+    <value>忽略此版本更新(&amp;I)</value>
   </data>
   <data name="&gt;&gt;SoftwareUpdateTitleLbl.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/PathCopyCopySettings/UI/UserControls/CommandLinePipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/CommandLinePipelineElementUserControl.zh-CN.resx
@@ -132,7 +132,7 @@
     <value>CmdLineToolTip</value>
   </data>
   <data name="ArgumentsLbl.Text" xml:space="preserve">
-    <value>&amp;参数：</value>
+    <value>参数(&amp;A):</value>
   </data>
   <data name="&gt;&gt;ArgumentsLbl.ZOrder" xml:space="preserve">
     <value>1</value>
@@ -171,7 +171,7 @@
     <value>要传递给可执行文件的参数。包括 %FILES%，以替换为文件路径，否则将附加路径。</value>
   </data>
   <data name="UseFilelistChk.Text" xml:space="preserve">
-    <value>Use &amp;filelist</value>
+    <value>使用列表文件(&amp;F)</value>
   </data>
   <data name="ArgumentsLbl.Location" type="System.Drawing.Point, System.Drawing">
     <value>-3, 31</value>

--- a/PathCopyCopySettings/UI/UserControls/CopyNPathPartsPipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/CopyNPathPartsPipelineElementUserControl.zh-CN.resx
@@ -177,13 +177,13 @@
     <value>3</value>
   </data>
   <data name="NumPartsTxt.ToolTip" xml:space="preserve">
-    <value>要复制路径的什么部分</value>
+    <value>要复制路径的多少部分</value>
   </data>
   <data name="CopyTheNLbl.Text" xml:space="preserve">
-    <value>&amp;复制</value>
+    <value>(&amp;C)复制路径的</value>
   </data>
   <data name="PathPartsLbl.Text" xml:space="preserve">
-    <value>路径的部分</value>
+    <value>部分</value>
   </data>
   <data name="FirstLastCombo.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>

--- a/PathCopyCopySettings/UI/UserControls/FindReplacePipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/FindReplacePipelineElementUserControl.zh-CN.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FindLbl.Text" xml:space="preserve">
-    <value>查找 &amp;what:</value>
+    <value>查找内容(&amp;W):</value>
   </data>
   <data name="&gt;&gt;FindTxt.ZOrder" xml:space="preserve">
     <value>0</value>

--- a/PathCopyCopySettings/UI/UserControls/PathsSeparatorPipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/PathsSeparatorPipelineElementUserControl.zh-CN.resx
@@ -151,7 +151,7 @@
     <value>1</value>
   </data>
   <data name="SeparatorLbl.Text" xml:space="preserve">
-    <value>&amp;Separator:</value>
+    <value>分隔符(&amp;S):</value>
   </data>
   <data name="&gt;&gt;SeparatorLbl.Parent" xml:space="preserve">
     <value>$this</value>

--- a/PathCopyCopySettings/UI/UserControls/PipelineElementWithExecutableUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/PipelineElementWithExecutableUserControl.zh-CN.resx
@@ -132,7 +132,7 @@
     <value>0</value>
   </data>
   <data name="ExecutableLbl.Text" xml:space="preserve">
-    <value>E&amp;xecutable:</value>
+    <value>可执行程序(&amp;X):</value>
   </data>
   <data name="&gt;&gt;ExecutableLbl.Name" xml:space="preserve">
     <value>ExecutableLbl</value>
@@ -190,7 +190,7 @@
     <value>2</value>
   </data>
   <data name="BrowseForExecutableBtn.Text" xml:space="preserve">
-    <value>&amp;Browse...</value>
+    <value>浏览(&amp;B)...</value>
   </data>
   <data name="BrowseForExecutableBtn.ToolTip" xml:space="preserve">
     <value>打开对话框并选择要在磁盘上启动的可执行文件。</value>

--- a/PathCopyCopySettings/UI/UserControls/PopFromStackPipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/PopFromStackPipelineElementUserControl.zh-CN.resx
@@ -124,7 +124,7 @@
     <value>IgnoreCaseChk</value>
   </data>
   <data name="EntireRadio.Text" xml:space="preserve">
-    <value>用它来替换&amp;整个路径</value>
+    <value>用它来替换整个路径(&amp;E)</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="RangeEndTxt.MaxLength" type="System.Int32, mscorlib">
@@ -141,7 +141,7 @@
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="EndRadio.Text" xml:space="preserve">
-    <value>在路径末&amp;尾插入数值</value>
+    <value>在路径末尾插入数值(&amp;N)</value>
   </data>
   <data name="RangeBeginTxt.ToolTip" xml:space="preserve">
     <value>Start of range to replace with the popped value</value>
@@ -153,7 +153,7 @@
     <value>295, 87</value>
   </data>
   <data name="TestRegexBtn.Text" xml:space="preserve">
-    <value>&amp;测试...</value>
+    <value>测试(&amp;T)...</value>
   </data>
   <data name="&gt;&gt;EntireRadio.ZOrder" xml:space="preserve">
     <value>11</value>
@@ -252,7 +252,7 @@
     <value>158, 13</value>
   </data>
   <data name="NowhereRadio.Text" xml:space="preserve">
-    <value>只需将其丢弃，&amp;无需储存</value>
+    <value>只需将其丢弃，无需储存(&amp;W)</value>
   </data>
   <data name="RangeEndTxt.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -267,7 +267,7 @@
     <value>打开一个对话框，测试正则表达式</value>
   </data>
   <data name="StartRadio.Text" xml:space="preserve">
-    <value>在路径的&amp;开头插入数值</value>
+    <value>在路径的开头插入数值(&amp;B)</value>
   </data>
   <data name="RangeBeginTxt.Size" type="System.Drawing.Size, System.Drawing">
     <value>27, 20</value>
@@ -303,7 +303,7 @@
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="RangeRadio.Text" xml:space="preserve">
-    <value>替换&amp;位置之间的所有路径</value>
+    <value>替换位置之间的所有路径(&amp;P)</value>
   </data>
   <data name="RangeBeginTxt.Location" type="System.Drawing.Point, System.Drawing">
     <value>264, 38</value>
@@ -321,7 +321,7 @@
     <value>7</value>
   </data>
   <data name="RegexRadio.Text" xml:space="preserve">
-    <value>替换&amp;正则表达式的第一个匹配项</value>
+    <value>替换正则表达式的第一个匹配项(&amp;R)</value>
   </data>
   <data name="&gt;&gt;BeginAndEndLbl.ZOrder" xml:space="preserve">
     <value>8</value>
@@ -502,7 +502,7 @@
     <value>PopFromStackPipelineElementUserControl</value>
   </data>
   <data name="IgnoreCaseChk.Text" xml:space="preserve">
-    <value>&amp;Ignore case</value>
+    <value>忽略大小写(&amp;I)</value>
   </data>
   <data name="&gt;&gt;RegexTxt.Parent" xml:space="preserve">
     <value>$this</value>

--- a/PathCopyCopySettings/UI/UserControls/PushToStackPipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/PushToStackPipelineElementUserControl.zh-CN.resx
@@ -159,7 +159,7 @@
     <value>1</value>
   </data>
   <data name="EntirePathRadio.Text" xml:space="preserve">
-    <value>&amp;整个路径</value>
+    <value>整个路径(&amp;E)</value>
   </data>
   <metadata name="PushToStackToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -192,7 +192,7 @@
     <value>2</value>
   </data>
   <data name="RangeRadio.Text" xml:space="preserve">
-    <value>&amp;位置间的路径上所有内容</value>
+    <value>位置间的路径上所有内容(&amp;P)</value>
   </data>
   <data name="RangeRadio.ToolTip" xml:space="preserve">
     <value>Push part of the path to the stack, as defined by a range of characters</value>
@@ -309,7 +309,7 @@
     <value>3</value>
   </data>
   <data name="RegexRadio.Text" xml:space="preserve">
-    <value>&amp;正则表达式匹配的第一个内容</value>
+    <value>正则表达式匹配的第一个内容(&amp;R)</value>
   </data>
   <data name="RegexRadio.ToolTip" xml:space="preserve">
     <value>将正则表达式的第一个匹配项入栈</value>
@@ -340,7 +340,7 @@
     <value>8</value>
   </data>
   <data name="RegexTxt.ToolTip" xml:space="preserve">
-    <value>Regular expression to use to locate the part of the path to push to the stack</value>
+    <value>正则表达式，用于确定路径中要推入堆栈的部分</value>
   </data>
   <data name="&gt;&gt;RegexTxt.Name" xml:space="preserve">
     <value>RegexTxt</value>
@@ -367,10 +367,10 @@
     <value>12</value>
   </data>
   <data name="IgnoreCaseChk.Text" xml:space="preserve">
-    <value>&amp;忽略大小写</value>
+    <value>忽略大小写(&amp;I)</value>
   </data>
   <data name="IgnoreCaseChk.ToolTip" xml:space="preserve">
-    <value>Whether to ignore case when using the regular expression to locate the part of the path to push to the stack</value>
+    <value>使用正则表达式确定路径中要推入堆栈的部分时，是否区分大小写</value>
   </data>
   <data name="&gt;&gt;IgnoreCaseChk.Name" xml:space="preserve">
     <value>IgnoreCaseChk</value>
@@ -397,7 +397,7 @@
     <value>13</value>
   </data>
   <data name="TestRegexBtn.Text" xml:space="preserve">
-    <value>&amp;测试...</value>
+    <value>测试(&amp;T)...</value>
   </data>
   <data name="TestRegexBtn.ToolTip" xml:space="preserve">
     <value>打开窗口测试正则表达式</value>
@@ -427,7 +427,7 @@
     <value>9</value>
   </data>
   <data name="UseGroupLbl1.Text" xml:space="preserve">
-    <value>(Use &amp;group</value>
+    <value>(&amp;G) (使用匹配分组</value>
   </data>
   <data name="&gt;&gt;UseGroupLbl1.Name" xml:space="preserve">
     <value>UseGroupLbl1</value>
@@ -511,7 +511,7 @@
     <value>4</value>
   </data>
   <data name="FixedStringRadio.Text" xml:space="preserve">
-    <value>The &amp;value</value>
+    <value>值(&amp;V)</value>
   </data>
   <data name="FixedStringRadio.ToolTip" xml:space="preserve">
     <value>将一个固定值入栈</value>
@@ -541,7 +541,7 @@
     <value>14</value>
   </data>
   <data name="FixedStringTxt.ToolTip" xml:space="preserve">
-    <value>Value to push to the stack</value>
+    <value>要推入堆栈的值</value>
   </data>
   <data name="&gt;&gt;FixedStringTxt.Name" xml:space="preserve">
     <value>FixedStringTxt</value>

--- a/PathCopyCopySettings/UI/UserControls/RegexPipelineElementUserControl.zh-CN.resx
+++ b/PathCopyCopySettings/UI/UserControls/RegexPipelineElementUserControl.zh-CN.resx
@@ -127,7 +127,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ReplaceLbl.Text" xml:space="preserve">
-    <value>&amp;替换表达式：</value>
+    <value>替换表达式(&amp;R)</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="ReplaceTxt.Location" type="System.Drawing.Point, System.Drawing">
@@ -169,7 +169,7 @@
     <value>是否在查找/替换时忽略大小写</value>
   </data>
   <data name="FindLbl.Text" xml:space="preserve">
-    <value>正则&amp;表达式：</value>
+    <value>正则表达式(&amp;X):</value>
   </data>
   <data name="IgnoreCaseChk.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -310,10 +310,10 @@
     <value>PathCopyCopy.Settings.UI.UserControls.PipelineElementUserControl, PathCopyCopySettings, Version=19.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="IgnoreCaseChk.Text" xml:space="preserve">
-    <value>&amp;忽略大小写</value>
+    <value>忽略大小写(&amp;I)</value>
   </data>
   <data name="TestBtn.Text" xml:space="preserve">
-    <value>&amp;测试...</value>
+    <value>测试(&amp;T)...</value>
   </data>
   <metadata name="RegexToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>


### PR DESCRIPTION
* 调整快捷键符号 (`&`) 的位置
* 使用正确的简体中文表述（去掉 PRC 字样），参考 [ms776294](https://web.archive.org/web/20120819210102/http://msdn.microsoft.com/en-us/library/ms776294.aspx) 对 `SUBLANG_CHINESE_SIMPLIFIED` 的表述

Locale identifier | Primary language | Prim. lang. identifier | Prim. lang. symbol | Sublanguage | Sublang. identifier | Sublang. symbol
-- | -- | -- | -- | -- | -- | --
`0x0804` | **Chinese (`zh`)** | `0x04` | `LANG_CHINESE_SIMPLIFIED` | **Simplified (`Hans`)** | 0x02 | **`SUBLANG_CHINESE_SIMPLIFIED`**
`0x0404` | Chinese (`zh`) |   | `LANG_CHINESE_TRADITIONAL` | Traditional (`Hant`) | 0x01 | `SUBLANG_CHINESE_TRADITIONAL`

需要你注意的：
* `PathCopyCopyLocalization_zh.rc` 中的“父目录”改成了“上级目录”，由你决定是否保留或全部修改
* “剪贴板”“剪切板”仍未统一
* 目前推荐使用 `zh-Hans` 代替 `zh-CN`，以便匹配新马等中国以外的作业环境，包括最新的 [MS-LCID](https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-LCID/%5bMS-LCID%5d.pdf) 也将 `zh-CN` (`0x0804`)、`zh-SG` (`0x1004`) 视为 `zh-Hans` (`Chinese (Simplified)`, `0x0004`) 的子集

发现错误可以直接改，不用征询我的意见。